### PR TITLE
added household screen and changed some routing

### DIFF
--- a/Common/src/Entity/Task.ts
+++ b/Common/src/Entity/Task.ts
@@ -1,8 +1,8 @@
 export default interface task {
   id?: string;
-  householdId: number;
-  description: string;
-  repeated: number;
-  archived: boolean;
-  value: 1 | 2 | 4 | 6 | 8;
+  householdId?: number;
+  description?: string;
+  repeated?: number;
+  archived?: boolean;
+  value?: 1 | 2 | 4 | 6 | 8;
 }

--- a/Common/src/Entity/household.ts
+++ b/Common/src/Entity/household.ts
@@ -1,5 +1,5 @@
 export default interface household {
-  id: string;
-  name: string;
-  JoinCode: number;
+  id?: string;
+  name?: string;
+  JoinCode?: number;
 }

--- a/firebase-api/functions/src/household/household.controller.ts
+++ b/firebase-api/functions/src/household/household.controller.ts
@@ -4,12 +4,12 @@ import {fb} from "../fb";
 const db = fb.firestore();
 const householdCollection = "household";
 
-interface Household {
-  name: string;
-  ownerId?: string;
-  members?: string[]; // FK
-  inviteCode: string;
-}
+// interface Household {
+//   name: string;
+//   ownerId?: string;
+//   members?: string[]; // FK
+//   inviteCode: string;
+// }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const post = async (req: Request, res: Response) => {
@@ -22,8 +22,9 @@ export const post = async (req: Request, res: Response) => {
       name: req.body["name"],
 
       // TODO: Fixa ownerId från usern som skapar hushållet
+      // och tilldela till owner och member
       //   ownerId: req.body["ownerId"],
-      members: req.body["members"],
+      member: req.body["members"],
       // TODO: Generera en inviteCode på ett smartare sätt?
       inviteCode: Math.floor(Math.random() * (max - min + 1) + min).toString(),
     };

--- a/firebase-api/functions/src/household/server.http
+++ b/firebase-api/functions/src/household/server.http
@@ -7,6 +7,9 @@ Content-Type: application/json
 }
 
 ###
+// Join household/inviteCode, kanske ska vara en post? 
 GET http://localhost:5000/react-native-household-app/us-central1/webApi/household/DHMGpAW5xR4k9GyaZdeI
 
-
+###
+// GET 
+GET http://localhost:5000/react-native-household-app/us-central1/webApi/household/DHMGpAW5xR4k9GyaZdeI

--- a/household-app/component/household.component/household.component.tsx
+++ b/household-app/component/household.component/household.component.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Text, View, Pressable, StyleSheet } from "react-native";
+import Household from "../../../Common/src/Entity/Household";
+import {
+  Avatar,
+  Button,
+  Card,
+  Title,
+  Paragraph,
+  List,
+} from "react-native-paper";
+import ItemSeparator from "../itemSeparator/itemSeparator.component";
+
+interface Props {
+  household: Household;
+  onPress: () => void;
+}
+
+export default function HouseholdComponent(props: Props) {
+  return (
+    // <View style = {styles.container}>
+    //   <List.Item style = {styles.item}
+    //     title= {props.household.name}
+    //     onPress ={props.onPress}
+    //     // description={props.household.name}
+    //     left={(props) => <List.Icon {...props} icon="home" />}
+    //   >
+    //   {/* <Pressable onPress={props.onPress}>
+    //     <View>
+    //       <Text>{props.household.name}</Text>
+    //       <Text>{props.household.JoinCode}</Text>
+    //     </View>
+    //   </Pressable> */}
+    //   </List.Item>
+    // </View>
+
+    <View>
+      <Pressable style={styles.title} onPress={props.onPress}>
+        <Text style={styles.text}>{props.household.name}</Text>
+      </Pressable>
+      <ItemSeparator />
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  container: {
+    // display: "flex",
+    // backgroundColor: "white",
+    // flexDirection: "column",
+    // alignItems: "center",
+    // padding: 8,
+  },
+  text: {
+    fontSize: 20,
+    padding: 12,
+  },
+  item: {
+    display: "flex",
+    backgroundColor: "white",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 8,
+  },
+  title: {
+    backgroundColor: "white",
+    flexDirection: "column",
+    alignItems: "center",
+    padding: 8,
+  },
+});

--- a/household-app/component/itemSeparator/itemSeparator.component.tsx
+++ b/household-app/component/itemSeparator/itemSeparator.component.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import {
+    View
+} from "react-native";
+
+const ItemSeparator = () => {
+  return (
+    <View
+      style={{
+        height: 2,
+        width: "100%",
+        backgroundColor: "#CED0CE",
+      }}
+    />
+  );
+};
+
+export default ItemSeparator;

--- a/household-app/component/taskFolder/taskItem.tsx
+++ b/household-app/component/taskFolder/taskItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Text, View, Pressable } from "react-native";
-import Task from "../../../Common/Entity/Task";
+import Task from "../../../Common/src/Entity/Task";
 
 interface Props {
   task: Task;

--- a/household-app/navigation/AppStack.tsx
+++ b/household-app/navigation/AppStack.tsx
@@ -11,6 +11,7 @@ import { Button, Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import LastWeekScreen from "../screens/Tasks/LastWeekScreen";
 import CurrentWeekScreen from "../screens/Tasks/CurrentWeekScreen";
+import HouseholdScreen from "../screens/Household/HouseholdScreen";
 
 const Stack = createNativeStackNavigator();
 const Tab = createMaterialTopTabNavigator();
@@ -23,6 +24,27 @@ const LoginStack = () => (
       options={{
         // headerShown: false,
         title: "Login",
+        headerTitleAlign: "center",
+        headerTintColor: "grey",
+        headerTitleStyle: {
+          fontWeight: "bold",
+        },
+        // headerRight: () => (
+        //   <MaterialIcons name="keyboard-arrow-right" size={24} color="black" />
+        // ),
+      }}
+    />
+  </MainStack.Navigator>
+);
+
+const HouseholdStack = () => (
+  <MainStack.Navigator>
+    <MainStack.Screen
+      name={MainRoutes.HouseholdScreen}
+      component={HouseholdScreen}
+      options={{
+        // headerShown: false,
+        title: "Households",
         headerTitleAlign: "center",
         headerTintColor: "grey",
         headerTitleStyle: {
@@ -124,13 +146,14 @@ const AppStack = () => {
     <Tab.Navigator
       screenOptions={{
         tabBarIndicatorStyle: { backgroundColor: "white" },
-        tabBarLabelStyle: { fontWeight: "bold" }
+        tabBarLabelStyle: { fontWeight: "bold" },
       }}
       // screenOptions={{lazy: true, tabBarStyle: {marginTop: insets.top}}}
     >
       <Tab.Screen name="Sign in" component={LoginStack} />
       <Tab.Screen name="Sign up" component={CreateStack} />
       <Tab.Screen name="Profile" component={ProfileStack} />
+      <Tab.Screen name="Households" component={HouseholdStack} />
     </Tab.Navigator>
   );
 };

--- a/household-app/navigation/TaskStack.tsx
+++ b/household-app/navigation/TaskStack.tsx
@@ -11,6 +11,7 @@ import { Button, Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import LastWeekScreen from "../screens/Tasks/LastWeekScreen";
 import CurrentWeekScreen from "../screens/Tasks/CurrentWeekScreen";
+import HouseholdScreen from "../screens/Household/HouseholdScreen";
 
 const Stack = createNativeStackNavigator();
 const Tab = createMaterialTopTabNavigator();

--- a/household-app/package-lock.json
+++ b/household-app/package-lock.json
@@ -12,9 +12,11 @@
         "react": "16.13.1",
         "react-dom": "16.13.1",
         "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
+        "react-native-appearance": "^0.3.4",
         "react-native-pager-view": "5.0.12",
         "react-native-paper": "^4.9.2",
         "react-native-safe-area-context": "3.2.0",
+        "react-native-tab-view": "^3.1.1",
         "react-native-web": "~0.13.12",
         "react-redux": "^7.2.5",
         "redux": "^4.1.1"
@@ -8725,6 +8727,16 @@
         "react": "16.13.1"
       }
     },
+    "node_modules/react-native-appearance": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-native-appearance/-/react-native-appearance-0.3.4.tgz",
+      "integrity": "sha512-Vz3zdJbAEiMDwuw6wH98TT1WVfBvWjvANutYtkIbl16KGRCigtSgt6IIiLsF3/TSS3y3FtHhWDelFeGw/rtuig==",
+      "dependencies": {
+        "fbemitter": "^2.1.1",
+        "invariant": "^2.2.4",
+        "use-subscription": "^1.0.0"
+      }
+    },
     "node_modules/react-native-pager-view": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-5.0.12.tgz",
@@ -8795,7 +8807,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-3.1.1.tgz",
       "integrity": "sha512-M5pRN6utQfytKWoKlKVzg5NbkYu308qNoW1khGTtEOTs1k14p2dHJ/BWOJoJYHKbPVUyZldbG9MFT7gUl4YHnw==",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
@@ -18424,6 +18435,16 @@
         }
       }
     },
+    "react-native-appearance": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-native-appearance/-/react-native-appearance-0.3.4.tgz",
+      "integrity": "sha512-Vz3zdJbAEiMDwuw6wH98TT1WVfBvWjvANutYtkIbl16KGRCigtSgt6IIiLsF3/TSS3y3FtHhWDelFeGw/rtuig==",
+      "requires": {
+        "fbemitter": "^2.1.1",
+        "invariant": "^2.2.4",
+        "use-subscription": "^1.0.0"
+      }
+    },
     "react-native-pager-view": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-5.0.12.tgz",
@@ -18476,7 +18497,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-3.1.1.tgz",
       "integrity": "sha512-M5pRN6utQfytKWoKlKVzg5NbkYu308qNoW1khGTtEOTs1k14p2dHJ/BWOJoJYHKbPVUyZldbG9MFT7gUl4YHnw==",
-      "peer": true,
       "requires": {}
     },
     "react-native-vector-icons": {

--- a/household-app/routes/routes.ts
+++ b/household-app/routes/routes.ts
@@ -8,6 +8,7 @@ export enum MainRoutes {
     TasksScreen = 'TasksScreen',
     LastWeekScreen = 'LastWeekScreen',
     CurrentWeekScreen = 'CurrentWeekScreen',
+    HouseholdScreen = 'HouseholdScreen'
 }
 
 export type MainStackParamList = {
@@ -17,6 +18,7 @@ export type MainStackParamList = {
     [MainRoutes.TasksScreen]: undefined
     [MainRoutes.LastWeekScreen]: undefined
     [MainRoutes.CurrentWeekScreen]: undefined
+    [MainRoutes.HouseholdScreen]: undefined
 }
 
 type ScreenName = keyof MainStackParamList;

--- a/household-app/screens/Household/HouseholdScreen.tsx
+++ b/household-app/screens/Household/HouseholdScreen.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from "react";
+import { FlatList, View } from "react-native";
+import Household from "../../../Common/src/Entity/household";
+import HouseholdComponent from "../../component/household.component/household.component";
+import { FeedStackScreenProps, MainRoutes } from "../../routes/routes";
+
+type Props = FeedStackScreenProps<MainRoutes.HouseholdScreen>;
+
+const HouseholdScreen: FC<Props> = ({
+  navigation,
+}: Props): React.ReactElement => {
+  const clickOnHousehold = () => {
+    navigation.navigate(MainRoutes.TasksScreen);
+  };
+
+  return (
+    <>
+      <View>
+        <View>
+          <View>
+            <FlatList
+              data={households}
+              keyExtractor={(item: any) => item.id}
+              renderItem={({ item }) => (
+                <HouseholdComponent
+                  key={item.id}
+                  household={item}
+                  onPress={clickOnHousehold}
+                />
+              )}
+            />
+          </View>
+        </View>
+      </View>
+    </>
+  );
+};
+
+export default HouseholdScreen;
+
+let households: Household[] = [
+  { name: "Hemma", JoinCode: 1234, id: "1" },
+  { name: "Stugan", JoinCode: 1337, id: "2" },
+];

--- a/household-app/screens/Tasks/TasksScreen.tsx
+++ b/household-app/screens/Tasks/TasksScreen.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import { View, Text, StyleSheet, FlatList, SafeAreaView } from "react-native";
-import Task from "../../../Common/Entity/Task";
+import Task from "../../../Common/src/Entity/Task";
 
 import TaskItem from '../../component/taskFolder/taskItem';
 import { FeedStackScreenProps, MainRoutes } from '../../routes/routes';
@@ -40,5 +40,5 @@ const styles = StyleSheet.create({
 
 let tasks: Task[] = [
   { description: "foo", value: 1, id: "abc" },
-  { description: "foo2", value: 3, id: "abc2" },
+  { description: "foo2", value: 2, id: "abc2" },
 ];

--- a/household-app/tsconfig.json
+++ b/household-app/tsconfig.json
@@ -5,7 +5,7 @@
   },
   "references": [
     {
-      "path": "../Common",
+      "path": "../Common/",
       // add 'prepend' if you want to include the referenced project in your output file
       "prepend": true
     }


### PR DESCRIPTION
The household screen is located in the appstack navigation. It renders a household component with hardcoded data values. We need to change this to the dynamic data coming from the backend later.

The screen renders a list of households, with each household item being pressable and routes the user to the tasks screen. Further implementation is needed to route to the right household tasks screen in the future.

closes #10 