### PR TITLE
Fixed safe area for status bar, as well as general styling stuff

### DIFF
--- a/household-app/component/householdComponents/household.component/household.component.tsx
+++ b/household-app/component/householdComponents/household.component/household.component.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { Text, View, Pressable, StyleSheet } from "react-native";
+import { Dimensions, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Surface } from "react-native-paper";
 import Household from "../../../Redux/entity/household";
-import { Avatar, Button, Card, Title, Paragraph, List } from "react-native-paper";
-import ItemSeparator from "../../itemSeparator/itemSeparator.component";
 
 interface Props {
     household: Household;
@@ -27,38 +26,38 @@ export default function HouseholdComponent(props: Props) {
         //   </List.Item>
         // </View>
 
-        <View>
-            <Pressable style={styles.title} onPress={props.onPress}>
-                <Text style={styles.text}>{props.household.name}</Text>
-            </Pressable>
-            <ItemSeparator />
-        </View>
+        <TouchableOpacity onPress={props.onPress}>
+            <Surface style={styles.container}>
+                <View>
+                    <Text style={styles.title}>{props.household.name}</Text>
+                </View>
+            </Surface>
+        </TouchableOpacity>
     );
 }
+const deviceWidth = Math.round(Dimensions.get("window").width);
 const styles = StyleSheet.create({
     container: {
-        // display: "flex",
-        // backgroundColor: "white",
-        // flexDirection: "column",
-        // alignItems: "center",
-        // padding: 8,
-    },
-    text: {
-        fontSize: 20,
-        padding: 12,
-    },
-    item: {
-        display: "flex",
-        backgroundColor: "white",
-        flexDirection: "column",
-        alignItems: "center",
+        width: deviceWidth - 20,
+        flexDirection: "row",
+        alignContent: "center",
         justifyContent: "center",
-        padding: 8,
+        alignSelf: "center",
+        borderRadius: 10,
+        marginVertical: 6,
+        elevation: 3,
+        shadowColor: "#000",
+        shadowOffset: {
+            width: 5,
+            height: 5,
+        },
+        shadowOpacity: 0.75,
+        shadowRadius: 5,
     },
     title: {
-        backgroundColor: "white",
-        flexDirection: "column",
-        alignItems: "center",
-        padding: 8,
+        fontWeight: "bold",
+        fontSize: 22,
+        marginHorizontal: 15,
+        marginVertical: 12,
     },
 });

--- a/household-app/component/taskFolder/TaskCard.tsx
+++ b/household-app/component/taskFolder/TaskCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { TouchableOpacity, View, StyleSheet, Dimensions, Text } from "react-native";
-import { Surface } from "react-native-paper";
-import { Badge } from "react-native-paper";
+import { Dimensions, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Badge, Surface } from "react-native-paper";
 
 interface TaskNow {
     id: string;

--- a/household-app/navigation/AppStack.tsx
+++ b/household-app/navigation/AppStack.tsx
@@ -12,9 +12,11 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import LastWeekScreen from "../screens/Tasks/LastWeekScreen";
 import CurrentWeekScreen from "../screens/Tasks/CurrentWeekScreen";
 import HouseholdScreen from "../screens/Household/HouseholdScreen";
+import Constants from "expo-constants";
 
 const Stack = createNativeStackNavigator();
 const Tab = createMaterialTopTabNavigator();
+const statusBarHeight = Constants.statusBarHeight;
 
 const LoginStack = () => (
     <MainStack.Navigator>
@@ -149,6 +151,7 @@ const AppStack = () => {
             screenOptions={{
                 tabBarIndicatorStyle: { backgroundColor: "white" },
                 tabBarLabelStyle: { fontWeight: "bold" },
+                tabBarStyle: { marginTop: statusBarHeight },
             }}
             // screenOptions={{lazy: true, tabBarStyle: {marginTop: insets.top}}}
         >

--- a/household-app/navigation/AuthStack.tsx
+++ b/household-app/navigation/AuthStack.tsx
@@ -12,8 +12,10 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import LastWeekScreen from "../screens/Tasks/LastWeekScreen";
 import CurrentWeekScreen from "../screens/Tasks/CurrentWeekScreen";
 import HouseholdScreen from "../screens/Household/HouseholdScreen";
+import Constants from "expo-constants";
 
 const Tab = createMaterialTopTabNavigator();
+const statusBarHeight = Constants.statusBarHeight;
 
 const LoginStack = () => (
     <MainStack.Navigator>
@@ -21,7 +23,7 @@ const LoginStack = () => (
             name={MainRoutes.LoginScreen}
             component={LoginScreen}
             options={{
-                // headerShown: false,
+                headerShown: false,
                 title: "Login",
                 headerTitleAlign: "center",
                 headerTintColor: "grey",
@@ -61,6 +63,7 @@ const AuthStack = () => {
             screenOptions={{
                 tabBarIndicatorStyle: { backgroundColor: "white" },
                 tabBarLabelStyle: { fontWeight: "bold" },
+                tabBarStyle: { marginTop: statusBarHeight },
             }}
             // screenOptions={{lazy: true, tabBarStyle: {marginTop: insets.top}}}
         >

--- a/household-app/navigation/MainNavigation.tsx
+++ b/household-app/navigation/MainNavigation.tsx
@@ -27,12 +27,12 @@ const MainNavigation = (): React.ReactElement => {
                 <Stack.Screen
                     name={MainRoutes.LoginScreen}
                     component={AuthStack}
-                    options={{ title: "", headerBackVisible: false }}
+                    options={{ title: "", headerBackVisible: false, headerShown: false }}
                 />
                 <Stack.Screen
                     name={MainRoutes.HouseholdScreen}
                     component={AppStack}
-                    options={{ title: "", headerBackVisible: false }}
+                    options={{ title: "", headerBackVisible: false, headerShown: false }}
                 />
                 <Stack.Screen
                     name={MainRoutes.TasksScreen}

--- a/household-app/navigation/TaskStack.tsx
+++ b/household-app/navigation/TaskStack.tsx
@@ -15,7 +15,6 @@ import HouseholdScreen from "../screens/Household/HouseholdScreen";
 
 const Stack = createNativeStackNavigator();
 const Tab = createMaterialTopTabNavigator();
-
 const TaskScreenStack = () => (
     <MainStack.Navigator>
         <MainStack.Screen
@@ -129,9 +128,9 @@ const TaskStack = () => {
         >
             {/* <Tab.Screen name="Sign in" component={LoginStack} />
       <Tab.Screen name="Sign up" component={CreateStack} /> */}
-            <Tab.Screen name="Last Week" component={LastWeekStack} />
-            <Tab.Screen name="Today" component={TaskScreenStack} />
-            <Tab.Screen name="Current Week" component={LastMonthStack} />
+            <Tab.Screen name="Idag" component={TaskScreenStack} />
+            <Tab.Screen name="Förra veckan" component={LastWeekStack} />
+            <Tab.Screen name="Denna månad" component={LastMonthStack} />
         </Tab.Navigator>
     );
 };

--- a/household-app/screens/Account/LoginScreen.tsx
+++ b/household-app/screens/Account/LoginScreen.tsx
@@ -46,7 +46,7 @@ const LoginScreen: FC<Props> = ({ navigation }: Props): React.ReactElement => {
     return (
         <View>
             <KeyboardAvoidingView
-                style={{ flexGrow: 1, height: "80%" }}
+                style={{ flexGrow: 1, height: "100%" }}
                 behavior={Platform.OS === "ios" ? "padding" : undefined}
                 enabled
             >

--- a/household-app/screens/Household/HouseholdScreen.tsx
+++ b/household-app/screens/Household/HouseholdScreen.tsx
@@ -1,24 +1,21 @@
-import React, { FC, useContext, useEffect, useState } from "react";
-import { FlatList, TouchableOpacity, View, Text, StyleSheet } from "react-native";
+import { FontAwesome5, MaterialCommunityIcons, MaterialIcons } from "@expo/vector-icons";
+import React, { FC, useContext, useState } from "react";
+import { FlatList, Text, TouchableOpacity, View } from "react-native";
+import AddHouseholdModal from "../../component/householdComponents/addHouseholdModal/addHouseholdModal.component";
 // import Household from "../../../Common(obsolete)/household";
 import HouseholdComponent from "../../component/householdComponents/household.component/household.component";
-import { FeedStackScreenProps, MainRoutes } from "../../routes/routes";
-import styles from "./styles";
-import { MaterialIcons, FontAwesome5 } from "@expo/vector-icons";
-import { MaterialCommunityIcons } from "@expo/vector-icons";
-import { baseProps } from "react-native-gesture-handler/lib/typescript/handlers/gestureHandlers";
-import AddHouseholdModal from "../../component/householdComponents/addHouseholdModal/addHouseholdModal.component";
 import JoinHouseholdModal from "../../component/householdComponents/joinHouseholdModal/joinHouseholdModal.component";
-import { selectCurrentLoginUser } from "../../Redux/features/loginUser/LoginSelectors";
-import { useAppDispatch, useAppSelector } from "../../Redux/hooks";
-import { logout } from "../../Redux/features/loginUser/loginUserSlice";
-import { useGetHouseholdByUserIdQuery } from "../../Redux/Service/household/householdApi";
-import Household from "../../Redux/entity/household";
-import { selectSelectedHousehold } from "../../Redux/features/SelectedState/SelectedStateSelectors";
-import { setSelectedHousehold } from "../../Redux/features/SelectedState/SelectedStateSlice";
-import household from "../../Redux/entity/household";
 import SnackbarComponent from "../../component/snackbar/snackbarComponent";
 import { snackbarContext } from "../../context/snackBarContext";
+import household from "../../Redux/entity/household";
+import { selectCurrentLoginUser } from "../../Redux/features/loginUser/LoginSelectors";
+import { logout } from "../../Redux/features/loginUser/loginUserSlice";
+import { selectSelectedHousehold } from "../../Redux/features/SelectedState/SelectedStateSelectors";
+import { setSelectedHousehold } from "../../Redux/features/SelectedState/SelectedStateSlice";
+import { useAppDispatch, useAppSelector } from "../../Redux/hooks";
+import { useGetHouseholdByUserIdQuery } from "../../Redux/Service/household/householdApi";
+import { FeedStackScreenProps, MainRoutes } from "../../routes/routes";
+import styles from "./styles";
 
 type Props = FeedStackScreenProps<MainRoutes.HouseholdScreen>;
 
@@ -70,10 +67,10 @@ const HouseholdScreen: FC<Props> = ({ navigation, route }: Props): React.ReactEl
         navigation.setOptions({
             headerRight: () => (
                 <TouchableOpacity
-                    onPress={onPressUsersInHousehold}
+                    onPress={onPressLogout}
                     // style={styles.householdButton}
                 >
-                    <FontAwesome5 name="house-user" size={24} color="black" />
+                    <FontAwesome5 name="sign-out-alt" size={24} color="black" />
                     {/* <Text style={styles.householdButtonText}>Medlemmar</Text> */}
                 </TouchableOpacity>
             ),
@@ -84,14 +81,8 @@ const HouseholdScreen: FC<Props> = ({ navigation, route }: Props): React.ReactEl
         <>
             <View style={styles.container}>
                 <SnackbarComponent isVisible={isVisible} message={message} />
-
-                <View style={styles.containerButton}>
-                    <TouchableOpacity onPress={onPressLogout} style={styles.logoutButton}>
-                        <Text style={styles.buttonText}>Sign out</Text>
-                    </TouchableOpacity>
-                </View>
                 <View>
-                    <View>
+                    <View style={styles.listContainer}>
                         <FlatList
                             data={data}
                             keyExtractor={(item: any) => item.id}

--- a/household-app/screens/Household/styles.ts
+++ b/household-app/screens/Household/styles.ts
@@ -1,5 +1,6 @@
-import { StyleSheet } from "react-native";
+import { Dimensions, StyleSheet } from "react-native";
 
+const deviceHeight = Math.round(Dimensions.get("window").height);
 const styles = StyleSheet.create({
     container: {
         flex: 1,
@@ -61,6 +62,9 @@ const styles = StyleSheet.create({
         bottom: 0,
         left: 0,
         right: 0,
+    },
+    listContainer: {
+        maxHeight: deviceHeight - 241,
     },
 });
 

--- a/household-app/screens/Tasks/TasksScreen.tsx
+++ b/household-app/screens/Tasks/TasksScreen.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Feather, MaterialIcons } from "@expo/vector-icons";
 import React, { FC, useEffect, useState } from "react";
-import { FlatList, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Dimensions, FlatList, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import TaskModal from "../../component/householdComponents/taskModal/taskModal";
 import ModalComponent from "../../component/modal/ModalComponent";
 import TaskCard from "../../component/taskFolder/TaskCard";
@@ -14,6 +14,7 @@ import { useGetTaskByHouseholdIdQuery } from "../../Redux/Service/task/taskApi";
 import { FeedStackScreenProps, MainRoutes } from "../../routes/routes";
 
 type Props = FeedStackScreenProps<MainRoutes.ProfileScreen>;
+const deviceHeight = Math.round(Dimensions.get("window").height);
 
 const TasksScreen: FC<Props> = ({ navigation, event }: Props): React.ReactElement => {
     const [addModalOpen, setAddModalOpen] = useState(false);
@@ -120,7 +121,7 @@ const TasksScreen: FC<Props> = ({ navigation, event }: Props): React.ReactElemen
     return (
         <View style={styles.container}>
             {render && (
-                <View>
+                <View style={styles.listContainer}>
                     <FlatList
                         data={tasks}
                         keyExtractor={(item: TaskNow) => item.id}
@@ -158,6 +159,9 @@ const TasksScreen: FC<Props> = ({ navigation, event }: Props): React.ReactElemen
 export default TasksScreen;
 
 const styles = StyleSheet.create({
+    listContainer: {
+        maxHeight: deviceHeight - 241,
+    },
     container: {
         flex: 1,
     },


### PR DESCRIPTION
Status bar is now considered as part of the views where top nav tabs are visible. Also set max height on the households and task flatlists so that the content doesnt overlap the bottom buttons on these screens. Changed the tab order in tasks screen as well