### PR TITLE
Sets time to 00.00 when creating tasks or done tasks

### DIFF
--- a/firebase-api/functions/src/doneTask/doneTask.controller.ts
+++ b/firebase-api/functions/src/doneTask/doneTask.controller.ts
@@ -9,11 +9,13 @@ const taskCollection = "doneTask";
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const postDoneTask = async (req: Request, res: Response) => {
   try {
+    const dateDone = new Date();
+    dateDone.setHours(0, 0, 0, 0);
     const doneTask: DoneTask = {
       taskId: req.body["taskId"],
       userId: req.body["userId"],
       value: req.body["value"],
-      dateDone: new Date(),
+      dateDone: dateDone,
       houseHoldId: req.body["houseHoldId"],
     };
 
@@ -26,7 +28,6 @@ export const postDoneTask = async (req: Request, res: Response) => {
     );
   }
 };
-
 
 export const getAllDoneTaskOfHouseHold = (req: Request, res: Response) => {
   const houseHoldId = req.params.houseHoldId;

--- a/firebase-api/functions/src/task/task.controller.ts
+++ b/firebase-api/functions/src/task/task.controller.ts
@@ -11,6 +11,8 @@ const taskCollection = "tasks";
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const postTask = async (req: Request, res: Response) => {
   try {
+    const dateDone = new Date();
+    dateDone.setHours(0, 0, 0, 0);
     const task: Task = {
       houseHoldId: req.body["houseHoldId"],
       repeated: req.body["repeated"],
@@ -18,7 +20,7 @@ export const postTask = async (req: Request, res: Response) => {
       description: req.body["description"],
       value: req.body["value"],
       name: req.body["name"],
-      createdAt: new Date(),
+      createdAt: dateDone,
     };
 
     const newDoc = await db.collection(taskCollection).add(task);
@@ -30,7 +32,6 @@ export const postTask = async (req: Request, res: Response) => {
     );
   }
 };
-
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getAllTaskOfHouseHold = (req: Request, res: Response) => {


### PR DESCRIPTION
When creating a new task or marking a task as done, the createdAt/doneDate values are now formatted as "2021-10-29:00:00:00" etc. This is to make the counter for when the task was created or made only take current date into account and discards the time of day it was created or marked as done.

For example: 
`Object {
  "archived": false,
  "createdAt": 2021-10-29T00:00:00.000Z,
  "description": "Skulle haft kondom",
  "emojiList": Array [],
  "householdId": "XwrUdjpNHzLLfWOxrC6C",
  "id": "zUcGSeTTFi6maLliTT7a",
  "name": "Hämta barnen",
  "repeated": 1,
  "value": 4,
}`

This creates a more desirable behaviour and the difference counter for tasks will update at the strike of midnight instead of also matching clock time. It's all UX, good stuff, as the intended use for the application is to also see what tasks are due that same day without regarding the time of day it was previous done.

closes #252 